### PR TITLE
Use global tabstop and shiftwidth.

### DIFF
--- a/indent/svelte.vim
+++ b/indent/svelte.vim
@@ -87,7 +87,6 @@ endif
 "
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 let &l:shiftwidth=&g:shiftwidth
-let &l:tabstop=&g:tabstop
 " JavaScript indentkeys
 setlocal indentkeys=0{,0},0),0],0\,,!^F,o,O,e,:,=:else
 " XML indentkeys

--- a/indent/svelte.vim
+++ b/indent/svelte.vim
@@ -86,7 +86,8 @@ endif
 " Settings {{{
 "
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-setlocal sw=2 ts=2
+let &l:shiftwidth=&g:shiftwidth
+let &l:tabstop=&g:tabstop
 " JavaScript indentkeys
 setlocal indentkeys=0{,0},0),0],0\,,!^F,o,O,e,:,=:else
 " XML indentkeys


### PR DESCRIPTION
Not sure if something else is relying on these values being `2` exactly but setting the local values of `shiftwidth` and `tabstop` this way should preserve the user's settings from their vimrc.