### PR TITLE
Support lang="typescript"

### DIFF
--- a/syntax/svelte.vim
+++ b/syntax/svelte.vim
@@ -182,7 +182,7 @@ syntax region coffeeSvelteScript fold
       \ keepend contains=@htmlCoffeeScript,jsImport,jsExport,svelteTag
 
 syntax region typescriptSvelteScript fold
-      \ start=+<script[^>]*lang="ts"[^>]*>+
+      \ start=+<script[^>]*lang="\(ts\|typescript\)"[^>]*>+
       \ end=+</script>+
       \ keepend contains=@TypeScript,svelteTag
 


### PR DESCRIPTION
According to [documentation](https://github.com/sveltejs/language-tools/blob/master/docs/preprocessors/typescript.md#2-getting-it-to-work-in-the-editor) `lang="typescript"` is supported in addition to `lang="ts"`.

As i prefer using it this way, this PR adds support for it.